### PR TITLE
Make app name determine toolchain name

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -13,7 +13,7 @@ template:
     git url: >-
       [{{repository}}]({{repository}})
 toolchain:
-  name: '{{baseName}}-{{timestamp}}'
+  name: '{{form.pipeline.parameters.app-name}}'
   template:
     getting_started:
       $ref: '#/messages/toolchain.getting_started'
@@ -50,6 +50,6 @@ form:
       dev-region: '{{region}}'
       dev-organization: '{{organization}}'
       dev-space: dev
-      app-name: '{{services.repo.parameters.repo_name}}'
+      app-name: '{{baseName}}-{{timestamp}}'
     schema:
       $ref: deploy.json


### PR DESCRIPTION
see https://github.ibm.com/org-ids/otc-integration-issues/issues/666

The D2BM flow is app-centric. This pull request changes the template such that the Application Name entered in the Delivery Pipeline section generates the Git Repository name and Toolchain Name.